### PR TITLE
fixing appocalypse link

### DIFF
--- a/interactions/slash/users/ipa.js
+++ b/interactions/slash/users/ipa.js
@@ -15,7 +15,7 @@ module.exports = {
             embeds: [
                 new EmbedBuilder()
                     .setTitle('Click here to join Appocalypse server')
-                    .setURL('https://discord.gg/8SXCXbzzBe/')
+                    .setURL('https://discord.gg/8SXCXbzzBe')
                     .setAuthor({ name: 'Appocalypse: Decrypted IPAs'})
                     .setColor('Random')
             ],


### PR DESCRIPTION
server invites should not have `/` at the end, i did a mistake and now it's fixed. sorry